### PR TITLE
Enable the use of callable structs similar to Distances.jl

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ evaluate(TokenSet(Jaro()), "martha", "marhta")
 evaluate(TokenMax(RatcliffObershelp()), "martha", "marhta")
 ```
 
+Alternatively, each `dist` struct can be used as a callable to call the evaluate function of each metric or modified metric, for example:
+```julia
+Jaro()("martha", "marhta")
+Winkler(Jaro())("martha", "marhta")
+QGram(2)("martha", "marhta")
+```
+
 A good distance to match strings composed of multiple words (like addresses) is `TokenMax(Levenshtein())` (see [fuzzywuzzy](http://chairnerd.seatgeek.com/fuzzywuzzy-fuzzy-string-matching-in-python/)).
 
 ## Compare

--- a/src/StringDistances.jl
+++ b/src/StringDistances.jl
@@ -30,6 +30,14 @@ julia> compare("martha", "marhta", Levenshtein())
 """
 compare(s1, s2, dist::StringDistance; min_score = 0.0) = 1 - evaluate(normalize(dist), s1, s2, 1 - min_score)
 
+const metrics = [Cosine, DamerauLevenshtein, Jaccard, Jaro, Levenshtein, Overlap, Partial, QGram,
+    RatcliffObershelp, SorensenDice, StringDistance,  TokenMax,
+    TokenSet, TokenSort, Winkler]
+
+for M in metrics
+    @eval @inline (dist::$M)(a::AbstractString, b::AbstractString) = evaluate(dist, a, b)
+end
+
 include("find.jl")
 
 ##############################################################################

--- a/test/distances.jl
+++ b/test/distances.jl
@@ -157,6 +157,16 @@ evaluate(DamerauLevenshtein(), [1,2,3], [1,2,10])
 evaluate(QGram(2), [1,2,3], [1,2,10])
 evaluate(Overlap(2), [1,2,3], [1,2,10])
 
+# use callable
+@test Levenshtein()("", "abc") == 3
+@test DamerauLevenshtein()("bc", "abc") == 1
+@test QGram(1)("abc", "cba") == 0
+@test Cosine(2)("leia", "leela") ≈ 0.7113249 atol = 1e-4
+@test Jaccard(2)("leia", "leela") ≈ 0.83333 atol = 1e-4
+@test SorensenDice(2)("night", "nacht") ≈ 0.75 atol = 1e-4
+@test Overlap(1)("context", "contact") ≈ .2 atol = 1e-4
+@test RatcliffObershelp()("pennsylvania",  "pencilvaneya") ≈ 1 - 0.6666666666666
+@test Jaro()(" vs an", "es an ") ≈ 0.2777777777777777
 
 #= R test
 library(stringdist)

--- a/test/modifiers.jl
+++ b/test/modifiers.jl
@@ -115,6 +115,13 @@ using StringDistances, Unicode, Test
 
 end
 
+# use callables
+@test Partial(Jaccard(2))("aa", "aa ") ≈ 0.0
+@test Winkler(Jaro(), p = 0.1, threshold = 0.0, maxlength = 4)("martha", "marhta") ≈ 0.0388 atol = 1e-4
+TokenMax(RatcliffObershelp())("aüa", "aua")
+@test Partial(RatcliffObershelp())("New York Yankees",  "Yankees") ≈ 0.0
+@test TokenSort(RatcliffObershelp())("New York Mets vs Atlanta Braves", "") ≈ 1.0
+@test TokenSet(RatcliffObershelp())("mariners vs angels", "") ≈ 1.0
 
 #= Python code
 from fuzzywuzzy import fuzz


### PR DESCRIPTION
The API of Distances.jl allows using each of the structs used for multiple dispatch as a callable function. For things such as https://github.com/JuliaNeighbors/VPTrees.jl it would be nice to be able to use the same API for StringDistances as well.
This PR copies the implementation from Distances.jl.