### PR TITLE
pairwise for calculating distance matrices

### DIFF
--- a/src/StringDistances.jl
+++ b/src/StringDistances.jl
@@ -11,7 +11,7 @@ const StringDistance = Union{Jaro, Levenshtein, DamerauLevenshtein, RatcliffOber
 # Distances API
 Distances.result_type(dist::StringDistance, s1, s2) = typeof(dist("", ""))
 include("find.jl")
-
+include("pairwise.jl")
 
 ##############################################################################
 ##
@@ -42,6 +42,7 @@ compare,
 result_type,
 qgrams,
 normalize,
-findnearest
+findnearest,
+pairwise
 end
 

--- a/src/pairwise.jl
+++ b/src/pairwise.jl
@@ -33,18 +33,18 @@ julia> pairwise(Levenshtein(), iter, iter2) # asymmetric
 pairwise
 
 pairwise(dist::StringDistance, X, Y; eltype = Float64, precalc = nothing) =
-    pairwise!(_allocmatrix(X, Y, eltype), dist, X, Y; precalc)
+    pairwise!(_allocmatrix(X, Y, eltype), dist, X, Y; precalc = precalc)
 
 pairwise(dist::StringDistance, X; eltype = Float64, precalc = nothing) =
-    pairwise!(_allocmatrix(X, eltype), dist, X; precalc)
+    pairwise!(_allocmatrix(X, eltype), dist, X; precalc = precalc)
 
 pairwise!(R::AbstractMatrix{N}, dist::StringDistance, X; precalc = nothing) where {N<:Number} =
     (dist isa SemiMetric) ?
-        _symmetric_pairwise!(R, dist, X; precalc) :
-        _asymmetric_pairwise!(R, dist, X, X; precalc)
+        _symmetric_pairwise!(R, dist, X; precalc = precalc) :
+        _asymmetric_pairwise!(R, dist, X, X; precalc = precalc)
 
 pairwise!(R::AbstractMatrix{N}, dist::StringDistance, X, Y; precalc = nothing) where {N<:Number} =
-    _asymmetric_pairwise!(R, dist, X, Y; precalc)
+    _asymmetric_pairwise!(R, dist, X, Y; precalc = precalc)
 
 _precalc(X, PT, q) = PT[PT(X[i], q) for i in 1:length(X)]
 

--- a/src/pairwise.jl
+++ b/src/pairwise.jl
@@ -28,7 +28,7 @@ julia> pairwise(Levenshtein(), iter, iter2) # asymmetric
  10.0
 ```
 """
-pairwise
+Distances.pairwise
 
 Distances.pairwise(dist::StringDistance, X, Y; eltype = Float64, preprocess = nothing) =
     pairwise!(_allocmatrix(X, Y, eltype), dist, X, Y; preprocess = preprocess)

--- a/src/pairwise.jl
+++ b/src/pairwise.jl
@@ -5,12 +5,13 @@ _allocmatrix(X, T) = Matrix{T}(undef, length(X), length(X))
     pairwise(dist::StringDistance, itr; eltype = Float64, preprocess = nothing)
     pairwise(dist::StringDistance, itr1, itr2; eltype = Float64, preprocess = nothing)
 
-Compute distances between all pairs of elements in `itr`according to the `StringDistance` 
-`dist`. The element type of the returned distance matrix can be set via `eltype`. 
+Compute distances between all pairs of elements in `itr` according to the
+`StringDistance` `dist`. The element type of the returned distance matrix
+can be set via `eltype`.
 
-For QGramDistances preprocessing will be used either if `preprocess` is set to true or 
-if there are more than 5 elements in `itr`. Set `preprocess` to false if no 
-preprocessing should be used, regardless of length.
+For QGramDistances preprocessing will be used either if `preprocess` is set 
+to true or if there are more than 5 elements in `itr`. Set `preprocess` to 
+false if no preprocessing should be used, regardless of length.
 
 Both symmetric and asymmetric versions are available.
 

--- a/src/pairwise.jl
+++ b/src/pairwise.jl
@@ -1,37 +1,56 @@
-_allocmat(X, Y, T) = Matrix{T}(undef, length(X), length(Y))
-_allocmat(X, T) = Matrix{T}(undef, length(X), length(X))
+_allocmatrix(X, Y, T) = Matrix{T}(undef, length(X), length(Y))
+_allocmatrix(X, T) = Matrix{T}(undef, length(X), length(X))
 
-pairwise(dist::StringDistance, X, Y; eltype = Float64) = 
-    pairwise!(_allocmat(X, Y, eltype), dist, X, Y)
+pairwise(dist::StringDistance, X, Y; eltype = Float64, precalc = nothing) =
+    pairwise!(_allocmatrix(X, Y, eltype), dist, X, Y; precalc)
 
-pairwise(dist::StringDistance, X; eltype = Float64) = 
-    pairwise!(_allocmat(X, eltype), dist, X)
+pairwise(dist::StringDistance, X; eltype = Float64, precalc = nothing) =
+    pairwise!(_allocmatrix(X, eltype), dist, X; precalc)
 
-function pairwise!(R::AbstractMatrix{N}, dist::StringDistance, X) where {N<:Number}
-    if dist isa SemiMetric
-        _symmetric_pairwise!(R, dist, X)
-    else
-        _asymmetric_pairwise!(R, dist, X, X)
-    end
-end
+pairwise!(R::AbstractMatrix{N}, dist::StringDistance, X; precalc = nothing) where {N<:Number} =
+    (dist isa SemiMetric) ?
+        _symmetric_pairwise!(R, dist, X; precalc) :
+        _asymmetric_pairwise!(R, dist, X, X; precalc)
 
-function pairwise!(R::AbstractMatrix{N}, dist::StringDistance, X, Y) where {N<:Number}
-    _asymmetric_pairwise!(R, dist, X, Y)
-end
+pairwise!(R::AbstractMatrix{N}, dist::StringDistance, X, Y; precalc = nothing) where {N<:Number} =
+    _asymmetric_pairwise!(R, dist, X, Y; precalc)
 
 _precalc(X, PT, q) = PT[PT(X[i], q) for i in 1:length(X)]
 
 const PrecalcMinLength = 5 # Only precalc if length >= 5
 
-function _symmetric_pairwise!(R, dist::QGramDistance, X; precalc = nothing, precalcType = QGramSortedVector)
-    # precalc if set to true or if isnothing and length is at least min length
-    shouldprecalc = (precalc === true) | (isnothing(precalc) & length(X) >= PrecalcMinLength)
-    objs = shouldprecalc ? _precalc(X, precalcType, q(dist)) : X
+function precalc_if_needed(X, dist::StringDistance, precalc, precalcType)
+    # precalc only if a QGramDistance and
+    # if precalc set to true or if isnothing and length is at least min length
+    !isa(dist, QGramDistance) && return X
+    cond = (precalc === true) ||
+                (isnothing(precalc) & length(X) >= PrecalcMinLength)
+    cond ? _precalc(X, precalcType, dist.q) : X
+end
+
+function _symmetric_pairwise!(R, dist::StringDistance, X;
+    precalc = nothing, precalcType = QGramSortedVector)
+
+    objs = precalc_if_needed(X, dist, precalc, precalcType)
 
     for i in 1:length(objs)
         R[i, i] = 0
-        for j in (i+1):length(objs)
+        Threads.@threads for j in (i+1):length(objs)
             R[i, j] = R[j, i] = evaluate(dist, objs[i], objs[j])
+        end
+    end
+    return R
+end
+
+function _asymmetric_pairwise!(R, dist::StringDistance, X, Y;
+    precalc = nothing, precalcType = QGramSortedVector)
+
+    objsX = precalc_if_needed(X, dist, precalc, precalcType)
+    objsY = precalc_if_needed(Y, dist, precalc, precalcType)
+
+    for i in 1:length(objsX)
+        Threads.@threads for j in 1:length(objsY)
+            R[i, j] = evaluate(dist, objsX[i], objsY[j])
         end
     end
     return R

--- a/src/pairwise.jl
+++ b/src/pairwise.jl
@@ -1,0 +1,38 @@
+_allocmat(X, Y, T) = Matrix{T}(undef, length(X), length(Y))
+_allocmat(X, T) = Matrix{T}(undef, length(X), length(X))
+
+pairwise(dist::StringDistance, X, Y; eltype = Float64) = 
+    pairwise!(_allocmat(X, Y, eltype), dist, X, Y)
+
+pairwise(dist::StringDistance, X; eltype = Float64) = 
+    pairwise!(_allocmat(X, eltype), dist, X)
+
+function pairwise!(R::AbstractMatrix{N}, dist::StringDistance, X) where {N<:Number}
+    if dist isa SemiMetric
+        _symmetric_pairwise!(R, dist, X)
+    else
+        _asymmetric_pairwise!(R, dist, X, X)
+    end
+end
+
+function pairwise!(R::AbstractMatrix{N}, dist::StringDistance, X, Y) where {N<:Number}
+    _asymmetric_pairwise!(R, dist, X, Y)
+end
+
+_precalc(X, PT, q) = PT[PT(X[i], q) for i in 1:length(X)]
+
+const PrecalcMinLength = 5 # Only precalc if length >= 5
+
+function _symmetric_pairwise!(R, dist::QGramDistance, X; precalc = nothing, precalcType = QGramSortedVector)
+    # precalc if set to true or if isnothing and length is at least min length
+    shouldprecalc = (precalc === true) | (isnothing(precalc) & length(X) >= PrecalcMinLength)
+    objs = shouldprecalc ? _precalc(X, precalcType, q(dist)) : X
+
+    for i in 1:length(objs)
+        R[i, i] = 0
+        for j in (i+1):length(objs)
+            R[i, j] = R[j, i] = evaluate(dist, objs[i], objs[j])
+        end
+    end
+    return R
+end

--- a/src/pairwise.jl
+++ b/src/pairwise.jl
@@ -1,6 +1,33 @@
 _allocmatrix(X, Y, T) = Matrix{T}(undef, length(X), length(Y))
 _allocmatrix(X, T) = Matrix{T}(undef, length(X), length(X))
 
+"""
+    pairwise(dist::StringDistance, itr; eltype = Float64, precalc = nothing)
+    pairwise(dist::StringDistance, itr1, itr2; eltype = Float64, precalc = nothing)
+
+`pairwise` returns the distance matrix between all pairs of elements in `itr`
+according to the distance `dist`. The element type of the returned matrix
+can be set via `eltype`. For QGramDistances precalculation will be used either
+if `precalc` is set to true or if there are more than 5 elements in `itr`.
+Set `precalc` to false if no precalculation should be used, regardless of length.
+
+Both symmetric and asymmetric versions are available.
+
+### Examples
+```julia-repl
+julia> using StringDistances
+julia> iter = ["New York", "Princeton"]
+julia> pairwise(Levenshtein(), iter) # symmetric
+2×2 Array{Float64,2}:
+ 0.0  9.0
+ 9.0  0.0
+julia> iter2 = ["San Francisco"]
+julia> pairwise(Levenshtein(), iter, iter2) # asymmetric
+2×1 Array{Float64,2}:
+ 12.0
+ 10.0
+```
+"""
 pairwise(dist::StringDistance, X, Y; eltype = Float64, precalc = nothing) =
     pairwise!(_allocmatrix(X, Y, eltype), dist, X, Y; precalc)
 

--- a/src/pairwise.jl
+++ b/src/pairwise.jl
@@ -1,7 +1,9 @@
 _allocmatrix(X, Y, T) = Matrix{T}(undef, length(X), length(Y))
 _allocmatrix(X, T) = Matrix{T}(undef, length(X), length(X))
 
-"""
+import Distances: pairwise
+
+@doc """
     pairwise(dist::StringDistance, itr; eltype = Float64, precalc = nothing)
     pairwise(dist::StringDistance, itr1, itr2; eltype = Float64, precalc = nothing)
 
@@ -28,6 +30,8 @@ julia> pairwise(Levenshtein(), iter, iter2) # asymmetric
  10.0
 ```
 """
+pairwise
+
 pairwise(dist::StringDistance, X, Y; eltype = Float64, precalc = nothing) =
     pairwise!(_allocmatrix(X, Y, eltype), dist, X, Y; precalc)
 

--- a/src/pairwise.jl
+++ b/src/pairwise.jl
@@ -5,11 +5,12 @@ _allocmatrix(X, T) = Matrix{T}(undef, length(X), length(X))
     pairwise(dist::StringDistance, itr; eltype = Float64, preprocess = nothing)
     pairwise(dist::StringDistance, itr1, itr2; eltype = Float64, preprocess = nothing)
 
-`pairwise` returns the distance matrix between all pairs of elements in `itr`
-according to the `StringDistance` `dist`. The element type of the returned matrix
-can be set via `eltype`. For QGramDistances preprocessing will be used either
-if `preprocess` is set to true or if there are more than 5 elements in `itr`.
-Set `preprocess` to false if no precalculation should be used, regardless of length.
+Compute distances between all pairs of elements in `itr`according to the `StringDistance` 
+`dist`. The element type of the returned distance matrix can be set via `eltype`. 
+
+For QGramDistances preprocessing will be used either if `preprocess` is set to true or 
+if there are more than 5 elements in `itr`. Set `preprocess` to false if no 
+preprocessing should be used, regardless of length.
 
 Both symmetric and asymmetric versions are available.
 

--- a/test/pairwise.jl
+++ b/test/pairwise.jl
@@ -71,9 +71,9 @@ TestStrings2 = ["mew", "ab"]
 			end
 		end
 
-		# Ensure same result if precalculating for QGramDistances
+		# Ensure same result if preprocessing for QGramDistances
 		if DT <: QGramDistance
-			R4 = pairwise(d, TestStrings1; precalc = true)
+			R4 = pairwise(d, TestStrings1; preprocess = true)
 			@test typeof(R4) == typeof(R)
 			@test size(R4) == size(R)
 			for i in 1:size(R4, 1)

--- a/test/pairwise.jl
+++ b/test/pairwise.jl
@@ -1,15 +1,19 @@
 using StringDistances, Unicode, Test, Random
+using StringDistances: pairwise, pairwise!, QGramDistance
 
 @testset "pairwise" begin
 
-TestStrings = ["", "abc", "bc", "kitten"]
+TestStrings1 = ["", "abc", "bc", "kitten"]
+TestStrings2 = ["mew", "ab"]
 
 @testset "pairwise" begin
-	for DT in [Levenshtein, Jaro]
-		d = DT()
-		R = pairwise(d, TestStrings)
+	for DT in [Jaro, Levenshtein, DamerauLevenshtein, RatcliffObershelp,
+				QGram, Cosine, Jaccard, SorensenDice, Overlap]
 
-		@test R isa Matrix{Float64, 2}
+		d = (DT <: QGramDistance) ? DT(2) : DT()
+		R = pairwise(d, TestStrings1)
+
+		@test R isa Matrix{Float64}
 		@test size(R) == (4, 4)
 
 		# No distance on the diagonal, since comparing strings to themselves
@@ -18,22 +22,64 @@ TestStrings = ["", "abc", "bc", "kitten"]
 		@test R[3, 3] == 0.0
 		@test R[4, 4] == 0.0
 
+		# Since the distance might be NaN:
+		equalorNaN(x, y) = (x == y) || (isnan(x) && isnan(y))
+
 		# First row is comparing "" to the other strings, so:
-		@test R[1, 2] == evaluate(d, "", "abc")
-		@test R[1, 3] == evaluate(d, "", "bc")
-		@test R[1, 4] == evaluate(d, "", "kitten")
+		@test equalorNaN(R[1, 2], evaluate(d, "", "abc"))
+		@test equalorNaN(R[1, 3], evaluate(d, "", "bc"))
+		@test equalorNaN(R[1, 4], evaluate(d, "", "kitten"))
 
 		# Second row is comparing "abc" to the other strings, so:
-		@test R[2, 3] == evaluate(d, "abc", "bc")
-		@test R[2, 4] == evaluate(d, "abc", "kitten")
+		@test equalorNaN(R[2, 3], evaluate(d, "abc", "bc"))
+		@test equalorNaN(R[2, 4], evaluate(d, "abc", "kitten"))
 
 		# Third row row is comparing "bc" to the other strings, so:
-		@test R[3, 4] == evaluate(d, "bc", "kitten")
+		@test equalorNaN(R[3, 4], evaluate(d, "bc", "kitten"))
 
 		# Matrix is symmetric
 		for i in 1:4
 			for j in (i+1):4
-				@test R[i, j] == R[j, i]
+				@test equalorNaN(R[i, j], R[j, i])
+			end
+		end
+
+		# Test also the assymetric version
+		R2 = pairwise(d, TestStrings1, TestStrings2)
+		@test R2 isa Matrix{Float64}
+		@test size(R2) == (4, 2)
+
+		@test equalorNaN(R2[1, 1], evaluate(d, "", "mew"))
+		@test equalorNaN(R2[1, 2], evaluate(d, "", "ab"))
+
+		@test equalorNaN(R2[2, 1], evaluate(d, "abc", "mew"))
+		@test equalorNaN(R2[2, 2], evaluate(d, "abc", "ab"))
+
+		@test equalorNaN(R2[3, 1], evaluate(d, "bc", "mew"))
+		@test equalorNaN(R2[3, 2], evaluate(d, "bc", "ab"))
+
+		@test equalorNaN(R2[4, 1], evaluate(d, "kitten", "mew"))
+		@test equalorNaN(R2[4, 2], evaluate(d, "kitten", "ab"))
+
+		R3 = pairwise(d, TestStrings2, TestStrings1)
+		@test R3 isa Matrix{Float64}
+		@test size(R3) == (2, 4)
+
+		for i in 1:length(TestStrings1)
+			for j in 1:length(TestStrings2)
+				@test equalorNaN(R2[i, j], R3[j, i])
+			end
+		end
+
+		# Ensure same result if precalculating for QGramDistances
+		if DT <: QGramDistance
+			R4 = pairwise(d, TestStrings1; precalc = true)
+			@test typeof(R4) == typeof(R)
+			@test size(R4) == size(R)
+			for i in 1:size(R4, 1)
+				for j in 1:size(R4, 2)
+					@test equalorNaN(R4[i, j], R[i, j])
+				end
 			end
 		end
 	end

--- a/test/pairwise.jl
+++ b/test/pairwise.jl
@@ -1,0 +1,42 @@
+using StringDistances, Unicode, Test, Random
+
+@testset "pairwise" begin
+
+TestStrings = ["", "abc", "bc", "kitten"]
+
+@testset "pairwise" begin
+	for DT in [Levenshtein, Jaro]
+		d = DT()
+		R = pairwise(d, TestStrings)
+
+		@test R isa Matrix{Float64, 2}
+		@test size(R) == (4, 4)
+
+		# No distance on the diagonal, since comparing strings to themselves
+		@test R[1, 1] == 0.0
+		@test R[2, 2] == 0.0
+		@test R[3, 3] == 0.0
+		@test R[4, 4] == 0.0
+
+		# First row is comparing "" to the other strings, so:
+		@test R[1, 2] == evaluate(d, "", "abc")
+		@test R[1, 3] == evaluate(d, "", "bc")
+		@test R[1, 4] == evaluate(d, "", "kitten")
+
+		# Second row is comparing "abc" to the other strings, so:
+		@test R[2, 3] == evaluate(d, "abc", "bc")
+		@test R[2, 4] == evaluate(d, "abc", "kitten")
+
+		# Third row row is comparing "bc" to the other strings, so:
+		@test R[3, 4] == evaluate(d, "bc", "kitten")
+
+		# Matrix is symmetric
+		for i in 1:4
+			for j in (i+1):4
+				@test R[i, j] == R[j, i]
+			end
+		end
+	end
+end
+
+end

--- a/test/performance/pairwise.jl
+++ b/test/performance/pairwise.jl
@@ -37,8 +37,8 @@ S = if isfile(CacheFile)
     end
 else
     println("Creating $N random strings.")
-    String[randstring(rand(3:Maxlength)) for _ in 1:N]
     SaveCache = true
+    String[randstring(rand(3:Maxlength)) for _ in 1:N]
 end
 
 if length(S) < N

--- a/test/performance/pairwise.jl
+++ b/test/performance/pairwise.jl
@@ -25,6 +25,8 @@ end
 # add new ones if needed.
 using Serialization
 const CacheFile = joinpath(@__DIR__(), "perfteststrings_$(Maxlength).juliabin")
+SaveCache = false
+
 S = if isfile(CacheFile)
     try
         res = deserialize(CacheFile)
@@ -36,12 +38,17 @@ S = if isfile(CacheFile)
 else
     println("Creating $N random strings.")
     String[randstring(rand(3:Maxlength)) for _ in 1:N]
+    SaveCache = true
 end
 
 if length(S) < N
     for i in (length(S)+1):N
         push!(S, randstring(rand(3:Maxlength)))
     end
+    SaveCache = true
+end
+
+if SaveCache
     println("Saving cache file with $(length(S)) strings: $CacheFile")
     serialize(CacheFile, S)
 end

--- a/test/performance/pairwise.jl
+++ b/test/performance/pairwise.jl
@@ -1,0 +1,34 @@
+using StringDistances, Random
+using BenchmarkTools
+
+N = if length(ARGS) > 0
+    try
+        parse(Int, ARGS[1])
+    catch _
+        100
+    end
+else
+    100 # default value
+end
+
+Maxlength = if length(ARGS) > 1
+    try
+        parse(Int, ARGS[2])
+    catch _
+        100
+    end
+else
+    100 # default value
+end
+
+S = String[randstring(rand(3:Maxlength)) for _ in 1:N]
+
+println("For ", Threads.nthreads(), " threads and ", N, " strings of max length ", Maxlength, ":")
+
+dist = Cosine(2)
+t1 = @belapsed dm1 = pairwise(dist, S; precalc = false)
+t2 = @belapsed dm2 = pairwise(dist, S; precalc = true)
+
+println("  - time WITHOUT pre-calculation: ", round(t1, digits = 3))
+println("  - time WITH    pre-calculation: ", round(t2, digits = 3))
+println("  - speedup with pre-calculation: ", round(t1/t2, digits = 1))

--- a/test/performance/pairwise.jl
+++ b/test/performance/pairwise.jl
@@ -26,8 +26,8 @@ S = String[randstring(rand(3:Maxlength)) for _ in 1:N]
 println("For ", Threads.nthreads(), " threads and ", N, " strings of max length ", Maxlength, ":")
 
 dist = Cosine(2)
-t1 = @belapsed dm1 = pairwise(dist, S; precalc = false)
-t2 = @belapsed dm2 = pairwise(dist, S; precalc = true)
+t1 = @belapsed dm1 = pairwise(dist, S; preprocess = false)
+t2 = @belapsed dm2 = pairwise(dist, S; preprocess = true)
 
 println("  - time WITHOUT pre-calculation: ", round(t1, digits = 3))
 println("  - time WITH    pre-calculation: ", round(t2, digits = 3))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,3 +3,4 @@ using Test
 
 include("distances.jl")
 include("modifiers.jl")
+include("pairwise.jl")


### PR DESCRIPTION
Adds `pairwise` methods similar to `Distances.pairwise` for calculating distance matrices. Both symmetric and asymmetric modes are supported and multiple threads should be used if available. Pre-calculation is used by default if there are more than 5 objects to be compared.