### PR TITLE
fix thread unsafety

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ version = "0.11.2"
 
 [deps]
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
-OhMyThreads = "67456a42-1dca-4109-a031-0a68de7e3ad5"
 StatsAPI = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -4,12 +4,13 @@ version = "0.11.2"
 
 [deps]
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
+OhMyThreads = "67456a42-1dca-4109-a031-0a68de7e3ad5"
 StatsAPI = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
 
 [compat]
 Distances = "0.8.1, 0.9, 0.10"
-julia = "1.3"
 StatsAPI = "1"
+julia = "1.3"
 
 [extras]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/src/StringDistances.jl
+++ b/src/StringDistances.jl
@@ -2,7 +2,7 @@ module StringDistances
 
 using Distances: Distances, SemiMetric, Metric, evaluate, result_type
 using StatsAPI: StatsAPI, pairwise, pairwise!
-using OhMyThreads: @one_by_one, @set, @tasks, GreedyScheduler, tmap
+
 # Distances API
 abstract type StringSemiMetric <: SemiMetric end
 abstract type StringMetric <: Metric end

--- a/src/StringDistances.jl
+++ b/src/StringDistances.jl
@@ -2,6 +2,7 @@ module StringDistances
 
 using Distances: Distances, SemiMetric, Metric, evaluate, result_type
 using StatsAPI: StatsAPI, pairwise, pairwise!
+using OhMyThreads: @tasks, @one_by_one, tmap
 # Distances API
 abstract type StringSemiMetric <: SemiMetric end
 abstract type StringMetric <: Metric end

--- a/src/StringDistances.jl
+++ b/src/StringDistances.jl
@@ -2,7 +2,7 @@ module StringDistances
 
 using Distances: Distances, SemiMetric, Metric, evaluate, result_type
 using StatsAPI: StatsAPI, pairwise, pairwise!
-using OhMyThreads: @tasks, @one_by_one, tmap
+using OhMyThreads: @one_by_one, @set, @tasks, GreedyScheduler, tmap
 # Distances API
 abstract type StringSemiMetric <: SemiMetric end
 abstract type StringMetric <: Metric end


### PR DESCRIPTION
fixes some potential race conditions involving the use of `threadid`. see `https://julialang.org/blog/2023/07/PSA-dont-use-threadid/` for details

I've chosen to use the library `OhMyThreads.jl` here, which did not exist at the time the original code here was written, but it's a quite nice + lightweight dependency to do parallel stuff