### PR TITLE
v1.0.0: bug fixes, cleanup, and modernization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.3'
+          - '1.6'
           - '1' # automatically expands to the latest stable 1.x release of Julia
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StringDistances"
 uuid = "88034a9c-02f8-509d-84a9-84ec65e18404"
-version = "0.11.4"
+version = "1.0.0"
 
 [deps]
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
@@ -9,7 +9,7 @@ StatsAPI = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
 [compat]
 Distances = "0.8.1, 0.9, 0.10"
 StatsAPI = "1"
-julia = "1.3"
+julia = "1.6"
 
 [extras]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ String distances act over any pair of iterators that define `length` (e.g. `Abst
 
 The available distances are:
 - Edit Distances
-	- Hamming Distance `Hamming() <: SemiMetric`
+	- Hamming Distance `Hamming() <: Metric`
 	- [Jaro and Jaro-Winkler Distance](https://en.wikipedia.org/wiki/Jaro%E2%80%93Winkler_distance) `Jaro()` `JaroWinkler() <: SemiMetric`
 	- [Levenshtein Distance](https://en.wikipedia.org/wiki/Levenshtein_distance) `Levenshtein() <: Metric`
 	- [Optimal String Alignment Distance](https://en.wikipedia.org/wiki/Damerau%E2%80%93Levenshtein_distance#Optimal_string_alignment_distance) (a.k.a. restricted Damerau-Levenshtein) `OptimalStringAlignment() <: SemiMetric`

--- a/src/StringDistances.jl
+++ b/src/StringDistances.jl
@@ -16,6 +16,8 @@ function Distances.result_type(dist::Union{StringSemiMetric, StringMetric}, s1::
 end
 
 
+# Fallback: swallow `max_dist` keyword for distances that don't support it,
+# so callers like Partial/TokenMax can pass max_dist generically.
 (dist::Union{StringSemiMetric, StringMetric})(s1, s2; max_dist = nothing) = dist(s1, s2)
 include("utils.jl")
 include("distances/edit.jl")

--- a/src/distances/edit.jl
+++ b/src/distances/edit.jl
@@ -98,7 +98,7 @@ function (dist::JaroWinkler)(s1, s2)
     (s1 === missing) | (s2 === missing) && return missing
     out = Jaro()(s1, s2)
     if out <= dist.threshold
-        l = common_prefix(s1, s2)[1]
+        l = common_prefix(s1, s2)
         out = (1 - min(l, dist.maxlength) * dist.p) * out
     end
     return out
@@ -246,7 +246,6 @@ function (dist::OptimalStringAlignment)(s1, s2; max_dist::Union{Integer, Nothing
     return Int(current)
 end
 
-Base.@deprecate_binding OptimalStringAlignement OptimalStringAlignment
 
 """
     DamerauLevenshtein()

--- a/src/distances/qgram.jl
+++ b/src/distances/qgram.jl
@@ -104,7 +104,6 @@ eval_end(::Overlap, c::NTuple{3, <:Integer}) = 1 - c[3] / min(c[1], c[2])
 
 """
 	NMD(q::Int)
-	NMD(q::Int)
 
 Creates a NMD (Normalized Multiset Distance) as introduced by Besiris and
 Zigouris 2013. The goal with this distance is to behave similarly to a normalized

--- a/src/find.jl
+++ b/src/find.jl
@@ -47,7 +47,7 @@ function findnearest(s, itr, dist::Union{StringSemiMetric, StringMetric}; min_sc
     chunk_score_tasks = map(data_chunks) do chunk
         Threads.@spawn begin
             map(chunk) do x
-                score = compare(_preprocessed_s, _preprocess(dist, x), dist; min_score = min_score)
+                score = compare(_preprocessed_s, _preprocess(dist, x), dist; min_score = min_score_atomic[])
                 Threads.atomic_max!(min_score_atomic, score)
                 score
             end
@@ -57,7 +57,7 @@ function findnearest(s, itr, dist::Union{StringSemiMetric, StringMetric}; min_sc
     # retrieve return type of `compare` for type stability in task
     _self_cmp = compare(_preprocessed_s, _preprocessed_s, dist; min_score = min_score)
     chunk_scores = fetch.(chunk_score_tasks)::Vector{Vector{typeof(_self_cmp)}}
-    scores = reduce(vcat, fetch.(chunk_scores))
+    scores = reduce(vcat, chunk_scores)
 
     imax = argmax(scores)
     iszero(scores) ? (nothing, nothing) : (_citr[imax], imax)
@@ -67,10 +67,6 @@ _preprocess(dist::AbstractQGramDistance, ::Missing) = missing
 _preprocess(dist::AbstractQGramDistance, s) = QGramSortedVector(s, dist.q)
 _preprocess(dist::Union{StringSemiMetric, StringMetric}, s) = s
 
-function Base.findmax(s, itr, dist::Union{StringSemiMetric, StringMetric}; min_score = 0.0)
-    @warn "findmax(s, itr, dist; min_score) is deprecated. Use findnearest(s, itr, dist; min_score)"
-    findnearest(s, itr, dist; min_score = min_score)
-end
 
 """
     findall(s, itr , dist::StringDistance; min_score = 0.8)
@@ -99,7 +95,7 @@ function Base.findall(s, itr, dist::Union{StringSemiMetric, StringMetric}; min_s
     _preprocessed_s = _preprocess(dist, s)
 
     chunk_size = max(1, length(_citr) ÷ (2 * Threads.nthreads()))
-    data_chunks = Iterators.partition(itr, chunk_size)
+    data_chunks = Iterators.partition(_citr, chunk_size)
     isempty(data_chunks) && return empty(eachindex(_citr))
     
     chunk_score_tasks = map(data_chunks) do chunk
@@ -114,6 +110,6 @@ function Base.findall(s, itr, dist::Union{StringSemiMetric, StringMetric}; min_s
     _self_cmp = compare(_preprocessed_s, _preprocessed_s, dist; min_score = min_score)
     chunk_scores::Vector{Vector{typeof(_self_cmp)}} = fetch.(chunk_score_tasks)
 
-    scores = reduce(vcat, fetch.(chunk_scores))
+    scores = reduce(vcat, chunk_scores)
     return findall(>=(min_score), scores)
 end


### PR DESCRIPTION
## Summary
- **Fix `findall` bug**: was using original iterator instead of collected copy for partitioning (would fail with generators)
- **Fix `findnearest` adaptive threshold**: `compare` now reads the atomic `min_score` so the threshold progressively tightens during search
- **Remove redundant `fetch.()` calls** in `findnearest` and `findall`
- **Remove deprecated bindings**: `OptimalStringAlignement` (4+ years) and `findmax` (5+ years)
- **Fix misleading `[1]` indexing** on `common_prefix()` in JaroWinkler, fix NMD duplicate docstring, fix README Hamming type
- **Bump Julia compat** from 1.3 to 1.6, update CI accordingly

## Test plan
- [x] Full test suite passes (2,646 tests) with `JULIA_NUM_THREADS=4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)