### PR TITLE
Prepare v1.1.0 with API, q-gram, bug-fix, and threading updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
+          - '1.8'
           - '1' # automatically expands to the latest stable 1.x release of Julia
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "StringDistances"
 uuid = "88034a9c-02f8-509d-84a9-84ec65e18404"
-version = "1.0.0"
+version = "1.1.0"
 
 [deps]
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"

--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ StatsAPI = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
 [compat]
 Distances = "0.8.1, 0.9, 0.10"
 StatsAPI = "1"
-julia = "1.6"
+julia = "1.8"
 
 [extras]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/README.md
+++ b/README.md
@@ -38,12 +38,13 @@ r = evaluate(Levenshtein(), x, y)
 r = Levenshtein()(x, y)
 ```
 
-The function `compare` returns the similarity score, defined as 1 minus the normalized distance between two strings. It always returns an element of type `Float64`. A value of 0.0 means completely different and a value of 1.0 means completely similar.
+The function `similarity` returns the similarity score, defined as 1 minus the normalized distance between two strings. It always returns an element of type `Float64`. A value of 0.0 means completely different and a value of 1.0 means completely similar.
+`compare` is kept as a deprecated alias for compatibility.
 
 ```julia
 Levenshtein()("martha", "martha")
 #> 0
-compare("martha", "martha", Levenshtein())
+similarity("martha", "martha", Levenshtein())
 #> 1.0
 ```
 
@@ -66,11 +67,13 @@ The package also adds convenience functions to find elements in a iterator of st
 	```julia
 	findnearest(s, itr, dist)
 	```
+	Missing entries in `itr` are ignored.
 
 - `findall` returns the indices of all elements in `itr` with a similarity score with `s` higher than a minimum score. Its syntax is:
 	```julia
 	findall(s, itr, dist; min_score = 0.8)
 	```
+	Missing entries in `itr` are ignored.
 
 The functions `findnearest` and `findall` are particularly optimized for the `Levenshtein` and `OptimalStringAlignment` distances, as these algorithm can stop early if the distance becomes higher than a certain threshold.
 
@@ -93,5 +96,4 @@ Partial(Levenshtein())("this string", "this string is longer") = 0
 
 ## Notes
 - All string distances are case sensitive.
-
-
+- For q-gram semimetrics other than `QGram`, when both inputs are shorter than `q`, identical inputs have distance `0.0` and different inputs have distance `1.0`.

--- a/benchmark/benchmark.jl
+++ b/benchmark/benchmark.jl
@@ -5,7 +5,7 @@ x = map(Random.randstring, rand(5:25,500_000))
 y = map(Random.randstring, rand(5:25,500_000))
 
 function f(t, x, y; min_score = 0.0)
-    [compare(x[i], y[i], t; min_score = min_score) for i in 1:length(x)]
+    [similarity(x[i], y[i], t; min_score = min_score) for i in 1:length(x)]
 end
 
 function g(dist, x, y)
@@ -83,4 +83,3 @@ system.time(stringdist(x,y,method='cosine', nthread = 1))
 system.time(stringdist(x,y,method='qgram', nthread = 1))
 
 =#
-

--- a/src/StringDistances.jl
+++ b/src/StringDistances.jl
@@ -59,6 +59,7 @@ MorisitaOverlap,
 NMD,
 qgrams,
 # normalize
+similarity,
 compare,
 # fuzzywuzzy
 Partial,
@@ -73,4 +74,3 @@ result_type,
 pairwise,
 pairwise!
 end
-

--- a/src/distances/qgram.jl
+++ b/src/distances/qgram.jl
@@ -1,5 +1,13 @@
 abstract type AbstractQGramDistance <: StringSemiMetric end
 
+@inline _no_qgrams(s, q::Integer) = length(s) < q
+@inline _short_qgram_distance(::AbstractQGramDistance, s1, s2) = Float64(s1 != s2)
+
+function _degenerate_qgram_distance(dist::AbstractQGramDistance, s1, s2)
+	(_no_qgrams(s1, dist.q) && _no_qgrams(s2, dist.q)) || return nothing
+	return _short_qgram_distance(dist, s1, s2)
+end
+
 """
 	QGram(q::Int)
 
@@ -15,6 +23,7 @@ that contains the number of times a q-gram appears for the string s
 struct QGram <: AbstractQGramDistance
 	q::Int
 end
+@inline _short_qgram_distance(::QGram, s1, s2) = 0
 eval_start(::QGram) = 0
 @inline function eval_op(::QGram, c::Integer, n1::Integer, n2::Integer)
 	c + abs(n1 - n2)
@@ -247,6 +256,8 @@ end
 
 function (dist::AbstractQGramDistance)(s1, s2)
 	(s1 === missing) | (s2 === missing) && return missing
+	degenerate = _degenerate_qgram_distance(dist, s1, s2)
+	degenerate === nothing || return degenerate
 	c = eval_start(dist)
 	for (n1, n2) in _count(qgrams(s1, dist.q), qgrams(s2, dist.q))
 		c = eval_op(dist, c, n1, n2)
@@ -309,6 +320,8 @@ end
 
 function (dist::AbstractQGramDistance)(qc1::QGramDict, qc2::QGramDict)
 	dist.q == qc1.q == qc2.q || throw(ArgumentError("The distance and the QGramDict must have the same qgram length"))
+	degenerate = _degenerate_qgram_distance(dist, qc1.s, qc2.s)
+	degenerate === nothing || return degenerate
 	d1, d2 = qc1.counts, qc2.counts
 	c = eval_start(dist)
 	for (s1, n1) in d1
@@ -375,6 +388,8 @@ end
 
 function (dist::AbstractQGramDistance)(qc1::QGramSortedVector, qc2::QGramSortedVector)
 	dist.q == qc1.q == qc2.q || throw(ArgumentError("The distance and the QGramSortedVectors must have the same qgram length"))
+	degenerate = _degenerate_qgram_distance(dist, qc1.s, qc2.s)
+	degenerate === nothing || return degenerate
 	d1, d2 = qc1.counts, qc2.counts
 	c = eval_start(dist)
 	i1 = i2 = 1

--- a/src/find.jl
+++ b/src/find.jl
@@ -1,18 +1,20 @@
 """
-    compare(s1, s2, dist)
+    similarity(s1, s2, dist)
 
 return a similarity score between 0 and 1 for the strings `s1` and 
 `s2` based on the distance `dist`.
 
 ### Examples
 ```julia-repl
-julia> compare("martha", "marhta", Levenshtein())
+julia> similarity("martha", "marhta", Levenshtein())
 0.6666666666666667
 ```
 """
-function compare(s1, s2, dist::Union{StringSemiMetric, StringMetric}; min_score = 0.0)
+function similarity(s1, s2, dist::Union{StringSemiMetric, StringMetric}; min_score = 0.0)
     1 - Normalized(dist)(s1, s2; max_dist = 1 - min_score)
 end
+
+Base.@deprecate compare(s1, s2, dist; min_score = 0.0) similarity(s1, s2, dist; min_score = min_score)
 
 """
     findnearest(s, itr, dist::Union{StringMetric, StringSemiMetric}) -> (x, index)
@@ -27,7 +29,7 @@ It is particularly optimized for [`Levenshtein`](@ref) and [`DamerauLevenshtein`
 ```julia-repl
 julia> using StringDistances
 julia> s = "Newark"
-julia> iter = ["New York", "Princeton", "San Francisco"]
+julia> iter = ["NewYork", "Princeton", "San Francisco"]
 julia> findnearest(s, iter, Levenshtein())
 ("NewYork", 1)
 julia> findnearest(s, iter, Levenshtein(); min_score = 0.9)
@@ -39,33 +41,31 @@ function findnearest(s, itr, dist::Union{StringSemiMetric, StringMetric}; min_sc
     isempty(_citr) && return (nothing, nothing)
 
     _preprocessed_s = _preprocess(dist, s)
-    min_score_atomic = Threads.Atomic{Float64}(min_score)
+    _preprocessed_s === missing && return (nothing, nothing)
+    ranges = _chunk_ranges(length(_citr))
+    scores = Vector{Float64}(undef, length(_citr))
 
-    chunk_size = max(1, length(_citr) ÷ (2 * Threads.nthreads()))
-    data_chunks = Iterators.partition(_citr, chunk_size)
-
-    chunk_score_tasks = map(data_chunks) do chunk
-        Threads.@spawn begin
-            map(chunk) do x
-                score = compare(_preprocessed_s, _preprocess(dist, x), dist; min_score = min_score_atomic[])
-                Threads.atomic_max!(min_score_atomic, score)
-                score
-            end
+    Threads.@threads :dynamic for ir in eachindex(ranges)
+        for i in ranges[ir]
+            scores[i] = _similarity_or_neg_inf(_preprocessed_s, _citr[i], dist; min_score = min_score)
         end
     end
 
-    # retrieve return type of `compare` for type stability in task
-    _self_cmp = compare(_preprocessed_s, _preprocessed_s, dist; min_score = min_score)
-    chunk_scores = fetch.(chunk_score_tasks)::Vector{Vector{typeof(_self_cmp)}}
-    scores = reduce(vcat, chunk_scores)
-
     imax = argmax(scores)
-    iszero(scores) ? (nothing, nothing) : (_citr[imax], imax)
+    scores[imax] > 0 ? (_citr[imax], imax) : (nothing, nothing)
 end
 
 _preprocess(dist::AbstractQGramDistance, ::Missing) = missing
 _preprocess(dist::AbstractQGramDistance, s) = QGramSortedVector(s, dist.q)
 _preprocess(dist::Union{StringSemiMetric, StringMetric}, s) = s
+
+function _similarity_or_neg_inf(_preprocessed_s, x, dist::Union{StringSemiMetric, StringMetric}; min_score = 0.0)
+    x === missing && return -Inf
+    _preprocessed_x = _preprocess(dist, x)
+    _preprocessed_x === missing && return -Inf
+    score = similarity(_preprocessed_s, _preprocessed_x, dist; min_score = min_score)
+    ismissing(score) ? -Inf : score
+end
 
 
 """
@@ -92,24 +92,18 @@ julia> findall(s, iter, Levenshtein(); min_score = 0.9)
 """
 function Base.findall(s, itr, dist::Union{StringSemiMetric, StringMetric}; min_score = 0.8)
     _citr = collect(itr)
+    isempty(_citr) && return Int[]
     _preprocessed_s = _preprocess(dist, s)
+    _preprocessed_s === missing && return Int[]
 
-    chunk_size = max(1, length(_citr) ÷ (2 * Threads.nthreads()))
-    data_chunks = Iterators.partition(_citr, chunk_size)
-    isempty(data_chunks) && return empty(eachindex(_citr))
-    
-    chunk_score_tasks = map(data_chunks) do chunk
-        Threads.@spawn begin
-            map(chunk) do x
-                compare(_preprocessed_s, _preprocess(dist, x), dist; min_score = min_score)
-            end
+    ranges = _chunk_ranges(length(_citr))
+    scores = Vector{Float64}(undef, length(_citr))
+
+    Threads.@threads :dynamic for ir in eachindex(ranges)
+        for i in ranges[ir]
+            scores[i] = _similarity_or_neg_inf(_preprocessed_s, _citr[i], dist; min_score = min_score)
         end
     end
 
-    # retrieve return type of `compare` for type stability in task
-    _self_cmp = compare(_preprocessed_s, _preprocessed_s, dist; min_score = min_score)
-    chunk_scores::Vector{Vector{typeof(_self_cmp)}} = fetch.(chunk_score_tasks)
-
-    scores = reduce(vcat, chunk_scores)
     return findall(>=(min_score), scores)
 end

--- a/src/pairwise.jl
+++ b/src/pairwise.jl
@@ -13,14 +13,14 @@ Both symmetric and asymmetric versions are available.
 julia> using StringDistances
 julia> iter = ["New York", "Princeton"]
 julia> pairwise(Levenshtein(), iter)
-2×2 Array{Float64,2}:
- 0.0  9.0
- 9.0  0.0
+2×2 Matrix{Int64}:
+ 0  9
+ 9  0
 julia> iter2 = ["San Francisco"]
 julia> pairwise(Levenshtein(), iter, iter2)
-2×1 Array{Float64,2}:
- 12.0
- 10.0
+2×1 Matrix{Int64}:
+ 12
+ 10
 ```
 """
 function StatsAPI.pairwise(dist::Union{StringSemiMetric, StringMetric}, xs::AbstractVector, ys::AbstractVector = xs; preprocess = true)
@@ -49,10 +49,10 @@ function _symmetric_pairwise!(R::AbstractMatrix, dist::Union{StringSemiMetric, S
     if preprocess
         xs = _preprocess_list(dist, xs)
     end
-    for i in 1:length(xs)
+    Threads.@threads :dynamic for i in 1:length(xs)
         # handle missing
         R[i, i] = xs[i] != xs[i]
-        Threads.@threads for j in (i+1):length(xs)
+        for j in (i+1):length(xs)
             R[i, j] = R[j, i] = evaluate(dist, xs[i], xs[j])
         end
     end
@@ -67,13 +67,43 @@ function _asymmetric_pairwise!(R::AbstractMatrix, dist::Union{StringSemiMetric, 
         objxs = xs
         objys = ys
     end
-    for i in 1:length(objxs)
-        Threads.@threads for j in 1:length(objys)
-            R[i, j] = evaluate(dist, objxs[i], objys[j])
+    if length(objxs) >= length(objys)
+        Threads.@threads :dynamic for i in 1:length(objxs)
+            for j in 1:length(objys)
+                R[i, j] = evaluate(dist, objxs[i], objys[j])
+            end
+        end
+    else
+        Threads.@threads :dynamic for j in 1:length(objys)
+            for i in 1:length(objxs)
+                R[i, j] = evaluate(dist, objxs[i], objys[j])
+            end
         end
     end
     return R
 end
 
 _preprocess_list(dist::Union{StringSemiMetric, StringMetric}, xs)  = xs
-_preprocess_list(dist::AbstractQGramDistance, xs) = fetch.(map(x -> (Threads.@spawn x === missing ? x : QGramSortedVector(x, dist.q)), xs))
+
+function _preprocess_list(dist::AbstractQGramDistance, xs::AbstractVector)
+    idx = findfirst(x -> x !== missing, xs)
+    idx === nothing && return copy(xs)
+
+    S = Base.nonmissingtype(eltype(xs))
+    if !isconcretetype(S)
+        return map(x -> x === missing ? x : QGramSortedVector(x, dist.q), xs)
+    end
+
+    sample = QGramSortedVector(xs[idx], dist.q)
+    T = Missing <: eltype(xs) ? Union{Missing, typeof(sample)} : typeof(sample)
+    out = Vector{T}(undef, length(xs))
+    ranges = _chunk_ranges(length(xs))
+
+    Threads.@threads :dynamic for ir in eachindex(ranges)
+        for i in ranges[ir]
+            x = xs[i]
+            out[i] = x === missing ? missing : QGramSortedVector(x, dist.q)
+        end
+    end
+    return out
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -53,4 +53,19 @@ function common_prefix(s1, s2)
     return l
 end
 
+_default_thread_count() = isdefined(Threads, :threadpoolsize) ? Threads.threadpoolsize() : Threads.nthreads()
+
+function _chunk_ranges(n::Integer; ntasks::Integer = 4 * _default_thread_count())
+    n <= 0 && return UnitRange{Int}[]
+    nchunks = min(Int(n), max(1, ntasks))
+    chunk_size = cld(Int(n), nchunks)
+    ranges = Vector{UnitRange{Int}}(undef, nchunks)
+    start = 1
+    for i in 1:nchunks
+        stop = min(Int(n), start + chunk_size - 1)
+        ranges[i] = start:stop
+        start = stop + 1
+    end
+    return ranges
+end
 

--- a/test/distances.jl
+++ b/test/distances.jl
@@ -263,9 +263,15 @@ using StringDistances, Unicode, Test, Random
 	end
 
 	@testset "QGram distance on short strings" begin
-		@test isnan(Overlap(2)( "1",  "2"))
-		@test isnan(Jaccard(3)("s1", "s2"))
-		@test isnan(Cosine(5)( "s1", "s2"))
+		@test Overlap(2)( "1",  "2") == 1.0
+		@test Jaccard(3)("s1", "s2") == 1.0
+		@test Cosine(5)( "s1", "s2") == 1.0
+
+		for d in (Cosine(2), Jaccard(2), SorensenDice(2), Overlap(2), MorisitaOverlap(2), NMD(2))
+			@test d("", "") == 0.0
+			@test d("a", "a") == 0.0
+			@test d("a", "b") == 1.0
+		end
 
 		@test !isnan(Overlap(2)( "s1",  "s2"))
 		@test !isnan(Jaccard(3)("st1", "st2"))
@@ -273,6 +279,16 @@ using StringDistances, Unicode, Test, Random
 
 		@test !isnan(Jaccard(3)("st1", "str2"))
 		@test !isnan(Jaccard(3)("str1", "st2"))
+
+		qd1 = QGramDict("", 2)
+		qd2 = QGramDict("a", 2)
+		@test Jaccard(2)(qd1, qd1) == 0.0
+		@test Jaccard(2)(qd1, qd2) == 1.0
+
+		qs1 = QGramSortedVector("", 2)
+		qs2 = QGramSortedVector("a", 2)
+		@test Jaccard(2)(qs1, qs1) == 0.0
+		@test Jaccard(2)(qs1, qs2) == 1.0
 	end
 
 	@testset "Differential testing of String, QGramDict, and QGramSortedVector" begin
@@ -321,8 +337,8 @@ using StringDistances, Unicode, Test, Random
 			(QGram(1), [0   3   3   1 3  0   6   4   5   4   4  11  14   0   0   3]),
 			(QGram(2), [  6   7   7   1 2 0   4   4   7   8   4  13  32   8   6   5]),
 			(Jaccard(1), [0.0 0.4285714 0.3750000 0.1666667       1.0 0.0 1.0000000 0.6666667 0.5714286 0.3750000 0.2000000 0.8333333 0.5000000 0.0 0.0 0.2500000]),
-			(Jaccard(2),  [ 0.7500000 0.8750000 0.7777778 0.1428571       1.0     NaN 1.0000000 1.0000000 0.7777778 0.8000000 0.3076923 1.0000000 0.9696970 0.6666667 1.0000000 0.8333333]),
-			(Cosine(2), [0.6000000 0.7763932 0.6220355 0.0741799  NaN  NaN 1.0000000 1.0000000 0.6348516 0.6619383 0.1679497 1.0000000 0.9407651 0.5000000 1.0000000 0.7113249]))
+			(Jaccard(2),  [ 0.7500000 0.8750000 0.7777778 0.1428571       1.0 0.0000000 1.0000000 1.0000000 0.7777778 0.8000000 0.3076923 1.0000000 0.9696970 0.6666667 1.0000000 0.8333333]),
+			(Cosine(2), [0.6000000 0.7763932 0.6220355 0.0741799  NaN 0.0000000 1.0000000 1.0000000 0.6348516 0.6619383 0.1679497 1.0000000 0.9407651 0.5000000 1.0000000 0.7113249]))
 	# Test with R package StringDist
 	for x in solutions
 		dist, solution = x
@@ -404,4 +420,3 @@ strings = [
 for x in strings:
    print(fuzz.ratio(x[0], x[1]))
 =#
-

--- a/test/modifiers.jl
+++ b/test/modifiers.jl
@@ -29,71 +29,73 @@ using StringDistances, Unicode, Random, Test
 	@test TokenMax(RatcliffObershelp())("martha", "marhta") ≈ 0.16666666 atol = 1e-5
 end
 
-@testset "Compare" begin
+@testset "Similarity" begin
 	# Qgram
-	@test compare("", "abc", QGram(1)) ≈ 0.0 atol = 1e-4
-	@test compare("abc", "cba", QGram(1)) ≈ 1.0 atol = 1e-4
-	@test compare("abc", "ccc", QGram(1)) ≈ 1/3 atol = 1e-4
-	compare("aüa", "aua", TokenMax(QGram(2)))
-	@test compare("", "abc", Jaccard(2)) ≈ 0.0 atol = 1e-4
-	@test compare("martha", "martha", Jaccard(2)) ≈ 1.0 atol = 1e-4
-	@test compare("martha", "martha", Jaccard(2)) ≈ 1.0 atol = 1e-4
-	@test compare("aa", "aa ", Partial(Jaccard(2))) ≈ 1.0
-	@test compare("martha", "martha", Cosine(2)) ≈ 1.0 atol = 1e-4
-	@test compare("martha", "martha", Overlap(2)) ≈ 1.0 atol = 1e-4
-	@test compare("martha", "martha", SorensenDice(2)) ≈ 1.0 atol = 1e-4
+	@test similarity("", "abc", QGram(1)) ≈ 0.0 atol = 1e-4
+	@test similarity("abc", "cba", QGram(1)) ≈ 1.0 atol = 1e-4
+	@test similarity("abc", "ccc", QGram(1)) ≈ 1/3 atol = 1e-4
+	similarity("aüa", "aua", TokenMax(QGram(2)))
+	@test similarity("", "abc", Jaccard(2)) ≈ 0.0 atol = 1e-4
+	@test similarity("martha", "martha", Jaccard(2)) ≈ 1.0 atol = 1e-4
+	@test similarity("martha", "martha", Jaccard(2)) ≈ 1.0 atol = 1e-4
+	@test similarity("aa", "aa ", Partial(Jaccard(2))) ≈ 1.0
+	@test similarity("martha", "martha", Cosine(2)) ≈ 1.0 atol = 1e-4
+	@test similarity("martha", "martha", Overlap(2)) ≈ 1.0 atol = 1e-4
+	@test similarity("martha", "martha", SorensenDice(2)) ≈ 1.0 atol = 1e-4
 
 	# Jaro
-	@test compare("aüa", "aua", Hamming()) ≈ 2/3
-	@test compare("aüa", "aua", Jaro()) ≈ 0.77777777 atol = 1e-4
-	@test compare("New York Yankees",  "", Partial(Jaro())) ≈ 0.0
+	@test similarity("aüa", "aua", Hamming()) ≈ 2/3
+	@test similarity("aüa", "aua", Jaro()) ≈ 0.77777777 atol = 1e-4
+	@test similarity("New York Yankees",  "", Partial(Jaro())) ≈ 0.0
 
 	# JaroWinkler
-	@test compare("martha", "marhta", JaroWinkler()) ≈ 0.9611 atol = 1e-4
-	@test compare("dwayne", "duane", JaroWinkler()) ≈ 0.84 atol = 1e-4
-	@test compare("dixon", "dicksonx", JaroWinkler()) ≈ 0.81333 atol = 1e-4
-	@test compare("william", "williams", JaroWinkler()) ≈ 0.975 atol = 1e-4
-	@test compare("", "foo", JaroWinkler()) ≈ 0.0 atol = 1e-4
-	@test compare("a", "a", JaroWinkler()) ≈ 1.0 atol = 1e-4
-	@test compare("abc", "xyz", JaroWinkler()) ≈ 0.0 atol = 1e-4
+	@test similarity("martha", "marhta", JaroWinkler()) ≈ 0.9611 atol = 1e-4
+	@test similarity("dwayne", "duane", JaroWinkler()) ≈ 0.84 atol = 1e-4
+	@test similarity("dixon", "dicksonx", JaroWinkler()) ≈ 0.81333 atol = 1e-4
+	@test similarity("william", "williams", JaroWinkler()) ≈ 0.975 atol = 1e-4
+	@test similarity("", "foo", JaroWinkler()) ≈ 0.0 atol = 1e-4
+	@test similarity("a", "a", JaroWinkler()) ≈ 1.0 atol = 1e-4
+	@test similarity("abc", "xyz", JaroWinkler()) ≈ 0.0 atol = 1e-4
 
 	#Levenshtein
-	compare("aüa", "aua", Levenshtein())
-	@test compare("ok", missing, Levenshtein()) === missing
-	compare("aüa", "aua", OptimalStringAlignment())
+	similarity("aüa", "aua", Levenshtein())
+	@test similarity("ok", missing, Levenshtein()) === missing
+	similarity("aüa", "aua", OptimalStringAlignment())
 	@test StringDistances.Normalized(Partial(OptimalStringAlignment()))("ab", "cde") == 1.0
-	@test compare("ab", "de", Partial(OptimalStringAlignment())) == 0
+	@test similarity("ab", "de", Partial(OptimalStringAlignment())) == 0
 
 	# RatcliffObershelp
-	@test compare("New York Mets vs Atlanta Braves", "", RatcliffObershelp())  ≈ 0.0
-	@test round(Int, 100 * compare("为人子女者要堂堂正正做人，千万不可作奸犯科，致使父母蒙羞", "此前稍早些时候中国商务部发布消息称，中美经贸高级别磋商双方牵头人通话，中方就美拟9月1日加征关税进行了严正交涉。", RatcliffObershelp())) == 5
-	compare("aüa", "aua", TokenMax(RatcliffObershelp()))
-	@test compare("New York Yankees",  "Yankees", Partial(RatcliffObershelp())) ≈ 1.0
-	@test compare("New York Yankees",  "", Partial(RatcliffObershelp())) ≈ 0.0
-	#@test compare("mariners vs angels", "los angeles angels at seattle mariners", Partial(RatcliffObershelp())) ≈ 0.444444444444
-	@test compare("HSINCHUANG", "SINJHUAN", Partial(RatcliffObershelp())) ≈ 0.875
-	@test compare("HSINCHUANG", "LSINJHUANG DISTRIC", Partial(RatcliffObershelp())) ≈ 0.8
-	@test compare("HSINCHUANG", "SINJHUANG DISTRICT", Partial(RatcliffObershelp())) ≈ 0.8
-	@test compare("HSINCHUANG",  "SINJHUANG", Partial(RatcliffObershelp())) ≈ 0.8888888888888
-	@test compare("New York Mets vs Atlanta Braves", "Atlanta Braves vs New York Mets", TokenSort(RatcliffObershelp())) ≈ 1.0
-	@test compare(graphemes("New York Mets vs Atlanta Braves"), graphemes("Atlanta Braves vs New York Mets"), Partial(RatcliffObershelp()))  ≈ compare("New York Mets vs Atlanta Braves", "Atlanta Braves vs New York Mets", Partial(RatcliffObershelp()))
-	@test compare("mariners vs angels", "los angeles angels of anaheim at seattle mariners", TokenSet(RatcliffObershelp())) ≈ 1.0 - 0.09090909090909094
-	@test compare("New York Mets vs Atlanta Braves", "", TokenSort(RatcliffObershelp()))  ≈ 0.0
-	@test compare("mariners vs angels", "", TokenSet(RatcliffObershelp())) ≈ 0.0
-	@test compare("mariners vs angels", "los angeles angels at seattle mariners", TokenSet(Partial(RatcliffObershelp()))) ≈ 1.0
-	@test compare("mariners", "mariner", TokenMax(RatcliffObershelp())) ≈ 0.933333333333333
-	@test compare("为人子女者要堂堂正正做人，千万不可作奸犯科，致使父母蒙羞", "此前稍早些时候中国商务部发布消息称，中美经贸高级别磋商双方牵头人通话，中方就美拟9月1日加征关税进行了严正交涉。", RatcliffObershelp()) ≈ 5 / 100 atol = 1e-2
-	@test compare("为人子女者要堂堂正正做人，千万不可作奸犯科，致使父母蒙羞", "此前稍早些时候中国商务部发布消息称，中美经贸高级别磋商双方牵头人通话，中方就美拟9月1日加征关税进行了严正交涉。", Partial(RatcliffObershelp())) ≈ 7 / 100 atol = 1e-2
-	@test compare("mariners", "mariner are playing tomorrow", TokenMax(RatcliffObershelp())) ≈ 79 / 100 atol = 1e-2
-	@test compare("mariners", "mariner are playing tomorrow mariner are playing tomorrow mariner are playing tomorrow mariner are playing tomorrow", Partial(RatcliffObershelp())) ≈ 88 / 100 atol = 1e-2
-	@test compare("mariners", "mariner are playing tomorrow mariner are playing tomorrow mariner are playing tomorrow mariner are playing tomorrow", TokenSort(RatcliffObershelp())) ≈ 11 / 100 atol = 1e-2
-	@test compare("mariners", "are mariner playing tomorrow", RatcliffObershelp()) ≈ 39 / 100 atol = 1e-2
-	@test compare("mariners", "are mariner playing tomorrow", Partial(RatcliffObershelp())) ≈ 88 / 100 atol = 1e-2
-	@test compare("mariners", "mariner are playing tomorrow mariner are playing tomorrow mariner are playing tomorrow mariner are playing tomorrow", TokenSet(RatcliffObershelp())) ≈ 39 / 100 atol = 1e-2
-	@test compare("mariners", "mariner are playing tomorrow mariner are playing tomorrow mariner are playing tomorrow mariner are playing tomorrow", TokenSet(Partial(RatcliffObershelp()))) ≈ 88 / 100 atol = 1e-2
+	@test similarity("New York Mets vs Atlanta Braves", "", RatcliffObershelp())  ≈ 0.0
+	@test round(Int, 100 * similarity("为人子女者要堂堂正正做人，千万不可作奸犯科，致使父母蒙羞", "此前稍早些时候中国商务部发布消息称，中美经贸高级别磋商双方牵头人通话，中方就美拟9月1日加征关税进行了严正交涉。", RatcliffObershelp())) == 5
+	similarity("aüa", "aua", TokenMax(RatcliffObershelp()))
+	@test similarity("New York Yankees",  "Yankees", Partial(RatcliffObershelp())) ≈ 1.0
+	@test similarity("New York Yankees",  "", Partial(RatcliffObershelp())) ≈ 0.0
+	#@test similarity("mariners vs angels", "los angeles angels at seattle mariners", Partial(RatcliffObershelp())) ≈ 0.444444444444
+	@test similarity("HSINCHUANG", "SINJHUAN", Partial(RatcliffObershelp())) ≈ 0.875
+	@test similarity("HSINCHUANG", "LSINJHUANG DISTRIC", Partial(RatcliffObershelp())) ≈ 0.8
+	@test similarity("HSINCHUANG", "SINJHUANG DISTRICT", Partial(RatcliffObershelp())) ≈ 0.8
+	@test similarity("HSINCHUANG",  "SINJHUANG", Partial(RatcliffObershelp())) ≈ 0.8888888888888
+	@test similarity("New York Mets vs Atlanta Braves", "Atlanta Braves vs New York Mets", TokenSort(RatcliffObershelp())) ≈ 1.0
+	@test similarity(graphemes("New York Mets vs Atlanta Braves"), graphemes("Atlanta Braves vs New York Mets"), Partial(RatcliffObershelp()))  ≈ similarity("New York Mets vs Atlanta Braves", "Atlanta Braves vs New York Mets", Partial(RatcliffObershelp()))
+	@test similarity("mariners vs angels", "los angeles angels of anaheim at seattle mariners", TokenSet(RatcliffObershelp())) ≈ 1.0 - 0.09090909090909094
+	@test similarity("New York Mets vs Atlanta Braves", "", TokenSort(RatcliffObershelp()))  ≈ 0.0
+	@test similarity("mariners vs angels", "", TokenSet(RatcliffObershelp())) ≈ 0.0
+	@test similarity("mariners vs angels", "los angeles angels at seattle mariners", TokenSet(Partial(RatcliffObershelp()))) ≈ 1.0
+	@test similarity("mariners", "mariner", TokenMax(RatcliffObershelp())) ≈ 0.933333333333333
+	@test similarity("为人子女者要堂堂正正做人，千万不可作奸犯科，致使父母蒙羞", "此前稍早些时候中国商务部发布消息称，中美经贸高级别磋商双方牵头人通话，中方就美拟9月1日加征关税进行了严正交涉。", RatcliffObershelp()) ≈ 5 / 100 atol = 1e-2
+	@test similarity("为人子女者要堂堂正正做人，千万不可作奸犯科，致使父母蒙羞", "此前稍早些时候中国商务部发布消息称，中美经贸高级别磋商双方牵头人通话，中方就美拟9月1日加征关税进行了严正交涉。", Partial(RatcliffObershelp())) ≈ 7 / 100 atol = 1e-2
+	@test similarity("mariners", "mariner are playing tomorrow", TokenMax(RatcliffObershelp())) ≈ 79 / 100 atol = 1e-2
+	@test similarity("mariners", "mariner are playing tomorrow mariner are playing tomorrow mariner are playing tomorrow mariner are playing tomorrow", Partial(RatcliffObershelp())) ≈ 88 / 100 atol = 1e-2
+	@test similarity("mariners", "mariner are playing tomorrow mariner are playing tomorrow mariner are playing tomorrow mariner are playing tomorrow", TokenSort(RatcliffObershelp())) ≈ 11 / 100 atol = 1e-2
+	@test similarity("mariners", "are mariner playing tomorrow", RatcliffObershelp()) ≈ 39 / 100 atol = 1e-2
+	@test similarity("mariners", "are mariner playing tomorrow", Partial(RatcliffObershelp())) ≈ 88 / 100 atol = 1e-2
+	@test similarity("mariners", "mariner are playing tomorrow mariner are playing tomorrow mariner are playing tomorrow mariner are playing tomorrow", TokenSet(RatcliffObershelp())) ≈ 39 / 100 atol = 1e-2
+	@test similarity("mariners", "mariner are playing tomorrow mariner are playing tomorrow mariner are playing tomorrow mariner are playing tomorrow", TokenSet(Partial(RatcliffObershelp()))) ≈ 88 / 100 atol = 1e-2
 	# not exactly the same because tokenmax has uses the max of rounded tokenset etc
-	@test compare("mariners", "mariner are playing tomorrow mariner are playing tomorrow mariner are playing tomorrow mariner are playing tomorrow", TokenMax(RatcliffObershelp())) ≈ 78.75 / 100 atol = 1e-2
+	@test similarity("mariners", "mariner are playing tomorrow mariner are playing tomorrow mariner are playing tomorrow mariner are playing tomorrow", TokenMax(RatcliffObershelp())) ≈ 78.75 / 100 atol = 1e-2
 
+	@test similarity("martha", "marhta", Levenshtein()) ≈ 2 / 3
+	@test_deprecated compare("martha", "marhta", Levenshtein())
 
 
 	# check min
@@ -117,10 +119,10 @@ end
 	]
 	for dist in (Levenshtein, OptimalStringAlignment)
 		for i in eachindex(strings)
-			if compare(strings[i]..., dist()) <  1 / 3
-				@test compare(strings[i]..., dist() ; min_score = 1/ 3) ≈ 0.0
+			if similarity(strings[i]..., dist()) <  1 / 3
+				@test similarity(strings[i]..., dist() ; min_score = 1/ 3) ≈ 0.0
 			else
-				@test compare(strings[i]..., dist() ; min_score = 1/ 3) ≈ compare(strings[i]..., dist())
+				@test similarity(strings[i]..., dist() ; min_score = 1/ 3) ≈ similarity(strings[i]..., dist())
 			end
 		end
 	end
@@ -132,15 +134,21 @@ end
 	@test findnearest("New York", ["NewYork", "Newark", "San Francisco"], Levenshtein()) == ("NewYork", 1)
 	@test findnearest("New York", ["San Francisco", "NewYork", "Newark"], Levenshtein()) == ("NewYork", 2)
 	@test findnearest("New York", ["Newark", "San Francisco", "NewYork"], Levenshtein()) == ("NewYork", 3)
+	@test findnearest("New York", ["NewYork", missing, "Newark"], Levenshtein()) == ("NewYork", 1)
+	@test findnearest("New York", [missing, missing], Levenshtein()) == (nothing, nothing)
 	@test findnearest("New York", ["NewYork", "Newark", "San Francisco"], Jaro()) == ("NewYork", 1)
 	@test findnearest("New York", ["NewYork", "Newark", "San Francisco"], QGram(2)) == ("NewYork", 1)
 	@test findnearest("New York", ["Newark", "San Francisco", "NewYork"], QGram(2)) == ("NewYork", 3)
+	@test findnearest("New York", [missing, "NewYork"], QGram(2)) == ("NewYork", 2)
 
 	# findall
 	@test findall("New York", ["NewYork", "Newark", "San Francisco"], Levenshtein()) == [1]
+	@test findall("New York", ["NewYork", missing, "Newark"], Levenshtein()) == [1]
+	@test findall("x", [missing], Levenshtein(); min_score = 0.0) == Int[]
 	@test findall("New York", ["NewYork", "Newark", "San Francisco"], Jaro()) == [1, 2]
 	@test findall("New York", ["NewYork", "Newark", "San Francisco"], Jaro(); min_score = 0.99) == Int[]
 	@test findall("New York", ["NewYork", "Newark", "San Francisco"], QGram(2); min_score = 0.99) == Int[]
+	@test findall("New York", [missing, "NewYork"], QGram(2); min_score = 0.7) == [2]
 
 
 
@@ -156,7 +164,7 @@ end
 	y = map(Random.randstring, rand(5:25,1_000))
 	x = Random.randstring(10)
 	for dist in (Levenshtein(), OptimalStringAlignment(), QGram(2), Partial(OptimalStringAlignment()), TokenMax(OptimalStringAlignment()))
-		result = [compare(x, y, dist) for y in y]
+		result = [similarity(x, y, dist) for y in y]
 		@test findnearest(x, y, dist)[2] == findmax(result)[2]
 		@test findall(x, y, dist; min_score = 0.4) == findall(result .>= 0.4)
 	end

--- a/test/pairwise.jl
+++ b/test/pairwise.jl
@@ -78,8 +78,11 @@ using StringDistances, Unicode, Test, Random
 				end
 			end
 		end
-		# ensures missing
-		R5 = pairwise(d, TestStrings1missing; preprocess = true)
-		@test eltype(R5) == Union{result_type(d, String, String), Missing}
-	end
+			# ensures missing
+			R5 = pairwise(d, TestStrings1missing; preprocess = true)
+			@test eltype(R5) == Union{result_type(d, String, String), Missing}
+		end
+
+		@test pairwise(Jaccard(2), ["", ""]) == [0.0 0.0; 0.0 0.0]
+		@test pairwise(Cosine(2), ["a", "a"]) == [0.0 0.0; 0.0 0.0]
 end


### PR DESCRIPTION
## Summary
This PR prepares the `1.1.0` release.

## Changes
- add `similarity` as the canonical public API and deprecate `compare`
- bump the package version to `1.1.0`
- define deterministic q-gram behavior when both inputs are shorter than `q`
  identical inputs now return distance `0.0`
  different inputs now return distance `1.0`
- update README/examples and benchmark script naming to use `similarity`

## Bug fixes
- make `findnearest` and `findall` ignore `missing` entries instead of failing
- add regression tests for `missing` handling and short-string q-gram edge cases
- fix stale docs/examples for `pairwise` and nearest-match examples

## Performance
- rework the threading model to use coarse-grained `Threads.@threads :dynamic` loops in `pairwise`, q-gram preprocessing, `findnearest`, and `findall`
- remove the previous many-small-task `@spawn` pattern
- benchmarked current vs previous HEAD on the same synthetic workload
  multithreaded results improved materially on the main paths, especially `pairwise`
  single-threaded results were mostly improved as well, with modest regressions on q-gram search

## Validation
- `Pkg.test()`
- `julia --compiled-modules=no --threads 4,1 --project=. -e "using StringDistances, Test; include(\"test/runtests.jl\")"`
- current-vs-HEAD benchmark comparison using a temporary harness on the same deterministic dataset
