### PR TITLE
Add v1.1.0 README notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@
 ## Installation
 The package is registered in the [`General`](https://github.com/JuliaRegistries/General) registry and so can be installed at the REPL with `] add StringDistances`.
 
+## What's New In 1.1
+- `similarity(s1, s2, dist)` is now the canonical API for similarity scores.
+  `compare(s1, s2, dist)` is still available as a deprecated alias for compatibility.
+- For q-gram semimetrics other than `QGram`, if both inputs are shorter than `q`, the distance is now defined as:
+  `0.0` when the inputs are equal
+  `1.0` when the inputs differ
+
 ## Supported Distances
 String distances act over any pair of iterators that define `length` (e.g. `AbstractStrings`, `GraphemeIterators`, or `AbstractVectors`)
 


### PR DESCRIPTION
## Summary
- add a short README note for 1.1
- document that  is the canonical API and  is deprecated
- document q-gram behavior when both inputs are shorter than 

## Testing
- not run (README-only change)